### PR TITLE
Nvmf storage tier: target independence

### DIFF
--- a/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/NvmfStorageClient.java
+++ b/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/NvmfStorageClient.java
@@ -1,3 +1,25 @@
+/*
+ * Crail: A Multi-tiered Distributed Direct Access File System
+ *
+ * Author:
+ * Jonas Pfefferle <jpf@zurich.ibm.com>
+ *
+ * Copyright (C) 2016, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.ibm.crail.storage.nvmf;
 
 import java.io.IOException;
@@ -24,7 +46,7 @@ public class NvmfStorageClient implements StorageClient {
 		}
 		initialized = true;
 		
-		NvmfStorageConstants.init(crailConfiguration, args);
+		NvmfStorageConstants.parseCmdLine(crailConfiguration, args);
 	}
 
 	public void printConf(Logger logger) {
@@ -34,7 +56,6 @@ public class NvmfStorageClient implements StorageClient {
 	public static NvmeEndpointGroup getEndpointGroup() {
 		if (clientGroup == null) {
 			clientGroup = new NvmeEndpointGroup(new NvmeTransportType[]{NvmeTransportType.RDMA},
-					NvmfStorageConstants.HUGEDIR,
 					NvmfStorageConstants.CLIENT_MEMPOOL);
 		}
 		return clientGroup;

--- a/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/NvmfStorageServer.java
+++ b/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/NvmfStorageServer.java
@@ -28,55 +28,44 @@ import com.ibm.crail.storage.StorageServer;
 import com.ibm.crail.utils.CrailUtils;
 import com.ibm.disni.nvmef.NvmeEndpoint;
 import com.ibm.disni.nvmef.NvmeEndpointGroup;
-import com.ibm.disni.nvmef.NvmeServerEndpoint;
-import com.ibm.disni.nvmef.spdk.NvmeController;
-import com.ibm.disni.nvmef.spdk.NvmeNamespace;
-import com.ibm.disni.nvmef.spdk.NvmeTransportType;
 
+import com.ibm.disni.nvmef.spdk.NvmeTransportType;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class NvmfStorageServer implements StorageServer {
 	private static final Logger LOG = CrailUtils.getLogger();
 
-	private NvmeEndpointGroup group;
-	private NvmeServerEndpoint serverEndpoint;
-	private Set<NvmeEndpoint> allEndpoints;
 	private boolean isAlive;
-	private NvmeController controller;
-	private NvmeNamespace namespace;
-	private long namespaceSize;
 	private long alignedSize;
-	private long addr;
+	private long offset;
 	private boolean initialized = false;
-	
-	public NvmfStorageServer() {
-		this.allEndpoints = ConcurrentHashMap.newKeySet();
-	}
+	private NvmeEndpoint endpoint;
+
+	public NvmfStorageServer() {}
 	
 	public void init(CrailConfiguration crailConfiguration, String[] args) throws Exception {
 		if (initialized) {
 			throw new IOException("NvmfStorageTier already initialized");
 		}
 		initialized = true;
-		NvmfStorageConstants.init(crailConfiguration, args);
-		
-		this.group = new NvmeEndpointGroup(new NvmeTransportType[]{NvmeTransportType.PCIE, NvmeTransportType.RDMA}, NvmfStorageConstants.HUGEDIR, NvmfStorageConstants.SERVER_MEMPOOL);
-		this.serverEndpoint = group.createServerEndpoint();
-		URI url = new URI("nvmef://" + NvmfStorageConstants.IP_ADDR.getHostAddress() + ":" + NvmfStorageConstants.PORT + "/0/1?subsystem=nqn.2016-06.io.spdk:cnode1&pci=" + NvmfStorageConstants.PCIE_ADDR);
-		serverEndpoint.bind(url);
-		this.isAlive = false;
-		
-		this.controller = serverEndpoint.getNvmecontroller();
-		this.namespace = controller.getNamespace(NvmfStorageConstants.NAMESPACE);
-		this.namespaceSize = namespace.getSize();
-		this.alignedSize = namespaceSize - (namespaceSize % NvmfStorageConstants.ALLOCATION_SIZE);	
-		this.addr = 0;
+		NvmfStorageConstants.parseCmdLine(crailConfiguration, args);
+
+		NvmeEndpointGroup group = new NvmeEndpointGroup(new NvmeTransportType[]{NvmeTransportType.RDMA}, NvmfStorageConstants.SERVER_MEMPOOL);
+		endpoint = group.createEndpoint();
+
+		URI uri = new URI("nvmef://" + NvmfStorageConstants.IP_ADDR.getHostAddress() + ":" + NvmfStorageConstants.PORT +
+					"/0/" + NvmfStorageConstants.NAMESPACE + "?subsystem=" + NvmfStorageConstants.NQN);
+		endpoint.connect(uri);
+
+		long namespaceSize = endpoint.getNamespaceSize();
+		alignedSize = namespaceSize - (namespaceSize % NvmfStorageConstants.ALLOCATION_SIZE);
+		offset = 0;
+
+		isAlive = true;
 	}	
 
 	@Override
@@ -84,28 +73,17 @@ public class NvmfStorageServer implements StorageServer {
 		NvmfStorageConstants.printConf(log);		
 	}
 
-	public void close(NvmeEndpoint ep) {
-		try {
-			allEndpoints.remove(ep);
-			LOG.info("removing endpoint, connCount " + allEndpoints.size());
-		} catch (Exception e){
-			LOG.info("error closing " + e.getMessage());
-		}
-	}
-
 	public void run() {
-		try {
-			this.isAlive = true;
-			LOG.info("RdmaDataNodeServer started at " + this.getAddress());
-			while(true){
-				NvmeEndpoint clientEndpoint = serverEndpoint.accept();
-				allEndpoints.add(clientEndpoint);
-				LOG.info("accepting client connection, conncount " + allEndpoints.size());
+		LOG.info("NnvmfStorageServer started with NVMf target " + getAddress());
+		while (isAlive) {
+			try {
+				Thread.sleep(1000 /* ms */);
+				endpoint.keepAlive();
+			} catch (Exception e) {
+				e.printStackTrace();
+				isAlive = false;
 			}
-		} catch(Exception e){
-			e.printStackTrace();
 		}
-		this.isAlive = false;
 	}
 
 	@Override
@@ -114,10 +92,10 @@ public class NvmfStorageServer implements StorageServer {
 		
 		if (alignedSize > 0){
 			LOG.info("new block, length " + NvmfStorageConstants.ALLOCATION_SIZE);
-			LOG.debug("block stag 0, addr " + addr + ", length " + NvmfStorageConstants.ALLOCATION_SIZE);
+			LOG.debug("block stag 0, offset " + offset + ", length " + NvmfStorageConstants.ALLOCATION_SIZE);
 			alignedSize -= NvmfStorageConstants.ALLOCATION_SIZE;
-			resource = StorageResource.createResource(addr, (int)NvmfStorageConstants.ALLOCATION_SIZE, 0);
-			addr += NvmfStorageConstants.ALLOCATION_SIZE;			
+			resource = StorageResource.createResource(offset, (int)NvmfStorageConstants.ALLOCATION_SIZE, 0);
+			offset += NvmfStorageConstants.ALLOCATION_SIZE;
 		}
 		
 		return resource;
@@ -130,6 +108,6 @@ public class NvmfStorageServer implements StorageServer {
 
 	@Override
 	public boolean isAlive() {
-		return this.isAlive;
+		return isAlive;
 	}
 }

--- a/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/client/NvmfStorageUnalignedWriteFuture.java
+++ b/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/client/NvmfStorageUnalignedWriteFuture.java
@@ -1,3 +1,25 @@
+/*
+ * Crail: A Multi-tiered Distributed Direct Access File System
+ *
+ * Author:
+ * Jonas Pfefferle <jpf@zurich.ibm.com>
+ *
+ * Copyright (C) 2016, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.ibm.crail.storage.nvmf.client;
 
 import com.ibm.crail.CrailBuffer;

--- a/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/client/NvmfStorageUtils.java
+++ b/storage-nvmf/src/main/java/com/ibm/crail/storage/nvmf/client/NvmfStorageUtils.java
@@ -1,3 +1,25 @@
+/*
+ * Crail: A Multi-tiered Distributed Direct Access File System
+ *
+ * Author:
+ * Jonas Pfefferle <jpf@zurich.ibm.com>
+ *
+ * Copyright (C) 2016, IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.ibm.crail.storage.nvmf.client;
 
 import com.ibm.crail.metadata.BlockInfo;


### PR DESCRIPTION
Make code NVMf target independent, i.e. the storage tier
can now be run with any target, e.g. SPDK, kernel, etc.
The storage tier connects to a running target to get
volume information and registers it to the namenode.
Before the code would actually start a NVMf target which
one now has to do by himself.